### PR TITLE
Misc changes for the tests

### DIFF
--- a/src/coreclr/inc/profilepriv.inl
+++ b/src/coreclr/inc/profilepriv.inl
@@ -1872,7 +1872,7 @@ inline BOOL CORProfilerTrackPinnedAllocations()
 
     return
             (CORProfilerPresent() &&
-            ((&g_profControlBlock)->dwEventMaskHigh & COR_PRF_HIGH_MONITOR_PINNEDOBJECT_ALLOCATED));
+            (&g_profControlBlock)->globalEventMask.IsEventMaskHighSet(COR_PRF_HIGH_MONITOR_PINNEDOBJECT_ALLOCATED));
 }
 
 inline BOOL CORProfilerEnableRejit()

--- a/src/tests/profiler/native/gcallocateprofiler/gcallocateprofiler.h
+++ b/src/tests/profiler/native/gcallocateprofiler/gcallocateprofiler.h
@@ -10,7 +10,8 @@ class GCAllocateProfiler : public Profiler
 public:
     GCAllocateProfiler() : Profiler(),
         _gcLOHAllocations(0),
-        _gcPOHAllocations(0)
+        _gcPOHAllocations(0),
+        _failures(0)
     {}
 
 	virtual GUID GetClsid();
@@ -21,4 +22,5 @@ public:
 private:
     std::atomic<int> _gcLOHAllocations;
     std::atomic<int> _gcPOHAllocations;
+    std::atomic<int> _failures;
 };

--- a/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
+++ b/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
@@ -15,7 +15,7 @@ HRESULT GCBasicProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
     Profiler::Initialize(pICorProfilerInfoUnk);
 
     HRESULT hr = S_OK;
-    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(0, 0x10)))
+    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(0, COR_PRF_HIGH_BASIC_GC)))
     {
         _failures++;
         printf("FAIL: ICorProfilerInfo::SetEventMask2() failed hr=0x%x", hr);
@@ -31,7 +31,7 @@ HRESULT GCBasicProfiler::Shutdown()
 
     if (_gcStarts == 0)
     {
-        printf("GCBasicProfiler::Shutdown: FAIL: Expected GarbaseCollectionStarted to be called\n");
+        printf("GCBasicProfiler::Shutdown: FAIL: Expected GarbageCollectionStarted to be called\n");
     }
     else if (_gcFinishes == 0)
     {

--- a/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
+++ b/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
@@ -31,7 +31,7 @@ HRESULT GCProfiler::Shutdown()
 
     if (_gcStarts == 0)
     {
-        printf("GCProfiler::Shutdown: FAIL: Expected GarbaseCollectionStarted to be called\n");
+        printf("GCProfiler::Shutdown: FAIL: Expected GarbageCollectionStarted to be called\n");
     }
     else if (_gcFinishes == 0)
     {


### PR DESCRIPTION
Fixes the build error after rebase.
Fixing the test failure by adding the flag.
Make sure we print out errors when they occur
Make sure we print out the string "PROFILER_TEST_PASSES\n" exactly as the harness is looking for it.
Instead of using assert, check for the conditions, so that it will work on release build, and
Fixing a few typos here and there.